### PR TITLE
NameError: global name 'TMDBLocaleError' is not defined

### DIFF
--- a/tmdb3/locales.py
+++ b/tmdb3/locales.py
@@ -6,6 +6,7 @@
 # Author: Raymond Wagner
 #-----------------------
 
+from tmdb_exceptions import *
 import locale
 
 syslocale = None


### PR DESCRIPTION
import statements is missing in locale.py which causes "NameError: global name 'TMDBLocaleError' is not defined" error
