### PR TITLE
Add votes and user rating to Images and remove Collection sorting

### DIFF
--- a/tmdb3/tmdb_api.py
+++ b/tmdb3/tmdb_api.py
@@ -656,6 +656,7 @@ class Collection( NameRepr, Element ):
     poster   = Datapoint('poster_path', handler=Poster, \
                             raw=False, default=None)
     members  = Datalist('parts', handler=Movie)
+    overview = Datapoint('overview')
 
     def _populate(self):
         return Request('collection/{0}'.format(self.id), \


### PR DESCRIPTION
Small change to allow votes and rating support to the Image class, as this data is available from the API.

Remove the sorting on Collection members by releasedate, as this field can be defined but blank in some cases and this leads to an error when sorting the list.
