### PR TITLE
Registered and uploaded on PyPI. Fix #31

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,13 @@
 
 from distutils.core import setup
 
+with open('README') as f:
+    long_description = f.read()
+
 setup(
     name='tmdb3',
     version='0.6.17',
     description='TheMovieDB.org APIv3 interface',
-    long_description="Object-oriented interface to TheMovieDB.org's v3 API.",
+    long_description=long_description,
     packages=['tmdb3']
 )


### PR DESCRIPTION
Library is now registered at https://pypi.python.org/pypi/tmdb3

pip install tmdb3 works as expected.

It you wan't, i can give you access to the registered package.
