### PR TITLE
Fix Unicode crashes when accessing trailer information

### DIFF
--- a/tmdb3/tmdb_api.py
+++ b/tmdb3/tmdb_api.py
@@ -393,6 +393,7 @@ class Trailer(Element):
 
 class YoutubeTrailer(Trailer):
     def geturl(self):
+        self.source = self.source.encode('ascii',errors='ignore')
         return "http://www.youtube.com/watch?v={0}".format(self.source)
 
     def __repr__(self):


### PR DESCRIPTION
 Added quick & dirty code to ignore strange unicode characters being returned in trailer URLs by the API.

For example, movie 180951 returns a 'LEFT-TO-RIGHT MARK' (U+200E) after the last character of the source.

This has been reported to TMDB at http://www.themoviedb.org/talk/543145fb0e0a2656e2001bc4 and they are working on fixing it.