### PR TITLE
Add manifest to include license and readme in packages. fix #59

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include README.md


### PR DESCRIPTION
This adds a manifest so that sdist packages include the license and readme files. Fixes crash on pip install with packages created after this is included.