### PR TITLE
fix: #26 check existence of datapoint.poller.func

### DIFF
--- a/tmdb3/util.py
+++ b/tmdb3/util.py
@@ -147,8 +147,8 @@ class Data(object):
         if inst is None:
             return self
         if self.field not in inst._data:
-            if self.poller is None:
-                return None
+            if self.poller.func is None:
+                return self.default
             self.poller.__get__(inst, owner)()
         return inst._data[self.field]
 


### PR DESCRIPTION
ElementType always creates a dummy poller for those Datapoints without function. (https://github.com/wagnerrp/pytmdb3/blob/07c849512d8043d74ecf90c85eb2c6445e09171e/tmdb3/util.py#L354)

So `self.poller is not None` in `Data.__get__` will never be True. (https://github.com/wagnerrp/pytmdb3/blob/07c849512d8043d74ecf90c85eb2c6445e09171e/tmdb3/util.py#L150)

It causes problem like #26 

Check `self.poller.func is not None` instead will fix it.