### PR TITLE
Fix getting errno from classname

### DIFF
--- a/tmdb3/tmdb_exceptions.py
+++ b/tmdb3/tmdb_exceptions.py
@@ -28,7 +28,7 @@ class TMDBError(Exception):
     def __init__(self, msg=None, errno=0):
         self.errno = errno
         if errno == 0:
-            self.errno = getattr(self, 'TMDB'+self.__class__.__name__, errno)
+            self.errno = getattr(self, self.__class__.__name__.lstrip('TMDB'), errno)
         self.args = (msg,)
 
 


### PR DESCRIPTION
```python
tk = TMDBKeyError()
assert tk.errno == 10
```

for the above code to work, the classname should stirp `TMDB` not prepend it.

https://github.com/wagnerrp/pytmdb3/blob/07c849512d8043d74ecf90c85eb2c6445e09171e/tmdb3/tmdb_exceptions.py#L31


